### PR TITLE
Fix for Webpack

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -58,7 +58,6 @@
     "source-map-loader": "^1.0.0",
     "style-loader": "^1.2.1",
     "ts-loader": "^7.0.5",
-    "webpack": "4.42.0",
     "webpack-cli": "^3.3.11"
   }
 }

--- a/client/package.json
+++ b/client/package.json
@@ -14,10 +14,10 @@
     "@types/react-redux": "^7.1.9",
     "@types/react-router-dom": "^5.1.5",
     "axios": "^0.19.2",
+    "lodash": "^4.17.15",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-redux": "^7.2.0",
-    "lodash": "^4.17.15",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
     "react-scripts": "^3.4.0",
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "webpack",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
@@ -58,6 +58,7 @@
     "source-map-loader": "^1.0.0",
     "style-loader": "^1.2.1",
     "ts-loader": "^7.0.5",
+    "webpack": "4.42.0",
     "webpack-cli": "^3.3.11"
   }
 }

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -17,7 +17,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "noEmit": true,
+    "noEmit": false,
     "jsx": "react"
   },
   "include": [

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -4,6 +4,7 @@ const HtmlWebpackPlugin = require("html-webpack-plugin");
 const bundleDir = path.join(__dirname, "dist");
 
 module.exports = {
+  mode: 'development',
   entry: "./src/index.jsx",
   devtool: 'inline-source-map',
   output: {

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1603,9 +1603,9 @@
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
 "@types/node@*":
-  version "14.0.9"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.9.tgz#43896ab87fc82bda1dfd600cdf44a0c8a64e11d2"
-  integrity sha512-0sCTiXKXELOBxvZLN4krQ0FPOAA7ij+6WwvD0k/PHd9/KAkr4dXel5J9fh6F4x1FwAQILqAWkmpeuS6mjf1iKA==
+  version "14.0.10"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.10.tgz#dbfaa170bd9eafccccb6d7060743a761b0844afd"
+  integrity sha512-Bz23oN/5bi0rniKT24ExLf4cK0JdvN3dH/3k0whYkdN4eI4vS2ZW/2ENNn2uxHCzWcbdHIa/GRuWQytfzCjRYw==
 
 "@types/node@^12.0.0":
   version "12.12.43"


### PR DESCRIPTION
File changes:
+ `package.json`
  + remove `webpack` completely because it is installed as a dependency with `create-react-app`
  + set build script to run `webpack`
+ `tsconfig.json`
  + set `noEmit` to `false` as to solve an error described [here](https://stackoverflow.com/questions/55304436/webpack-with-typescript-getting-typescript-emitted-no-output-error)

To run webpack (and produce the bundle), run `yarn run build`