### PR TITLE
Simplify page header component

### DIFF
--- a/client/src/components/Page.tsx
+++ b/client/src/components/Page.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { Grid } from "@material-ui/core";
 import { withStyles, createStyles, Theme } from "@material-ui/core/styles";
-import Typography from "@material-ui/core/Typography";
 
 const pageHeaderStyle = (theme: Theme) =>
   createStyles({
@@ -18,58 +17,16 @@ const pageBodyStyle = (theme: Theme) =>
     },
   });
 
-const pageBodyGutterStyle = (theme: Theme) =>
-  createStyles({
-    root: {
-      backgroundColor: theme.palette.background.default,
-    },
-  });
-
-const pageHeaderGutterStyle = (theme: Theme) =>
-  createStyles({
-    root: {
-      backgroundColor: theme.palette.primary.light,
-    },
-  });
-
-const PageHeaderGutter = withStyles(pageHeaderGutterStyle)((props: any) => (
-  <Grid item {...props}>
-    {props.children}
-  </Grid>
-));
-
-const PageBodyGutter = withStyles(pageBodyGutterStyle)((props: any) => (
-  <Grid item {...props}>
-    {props.children}
-  </Grid>
-));
-
 const PageHeader = withStyles(pageHeaderStyle)((props: any) => (
-  <Grid
-    container
-    direction="row"
-    justify="flex-start"
-    alignItems="flex-end"
-    {...props}
-  >
-    <PageHeaderGutter sm={1} />
-    <Grid item xs={10} sm={10} style={{ height: "40%" }}>
-      <Typography variant="h1" style={{ paddingBottom: "10px" }} {...props}>
-        {props.header}
-      </Typography>
-    </Grid>
-    <PageHeaderGutter sm={1} />
+  <Grid item style={{ height: "25%", padding: "0px 12%", width: "100%" }} {...props}>
+    {props.children}
   </Grid>
 ));
 
 const PageBody = withStyles(pageBodyStyle)((props: any) => (
-  <Grid container direction="row" style={{ height: "100%" }}>
-    <PageBodyGutter sm={1} />
-    <Grid item xs={12} sm={10} {...props}>
-      {props.children}
-    </Grid>
-    <PageBodyGutter sm={1} />
+  <Grid item style={{ height: "75%", padding: "0px 12%", width: "100%" }} {...props}>
+    {props.children}
   </Grid>
 ));
 
-export { PageHeader, PageBody, PageBodyGutter, PageHeaderGutter };
+export { PageHeader, PageBody };

--- a/client/src/components/index.tsx
+++ b/client/src/components/index.tsx
@@ -2,10 +2,10 @@ import { ContainedButton, DarkContainedButton, TextButton, Button } from "./Butt
 import Link from "./Link";
 import { OutlinedTextField, TextField } from "./TextField";
 import { ContainedSelect, Select } from "./Select";
-import { PageHeader, PageBody, PageBodyGutter, PageHeaderGutter } from "./Page";
+import { PageHeader, PageBody } from "./Page";
 
 export { ContainedButton, DarkContainedButton, TextButton, Button };
 export { Link };
 export { OutlinedTextField, TextField };
 export { ContainedSelect, Select };
-export { PageHeader, PageBody, PageBodyGutter, PageHeaderGutter };
+export { PageHeader, PageBody };

--- a/client/src/pages/Requests/TestSection.jsx
+++ b/client/src/pages/Requests/TestSection.jsx
@@ -1,54 +1,73 @@
-import React from 'react';
-import { connect } from 'react-redux';
+import React from "react";
+import { connect } from "react-redux";
 
 /* Services */
-import { fetchTestService } from '../../data/services/testServices';
+import { fetchTestService } from "../../data/services/testServices";
 
 /* Selectors */
-import { getTests } from '../../data/selectors/testSelector';
+import { getTests } from "../../data/selectors/testSelector";
 
 /* Components */
 import { Grid } from "@material-ui/core";
-import { ContainedButton, PageHeader, PageBody } from '../../components/index';
+import { ContainedButton, PageHeader, PageBody } from "../../components/index";
+import Typography from "@material-ui/core/Typography";
 
-const mapStateToProps = state => ({
-    users: getTests(state),
-})
+const mapStateToProps = (state) => ({
+  users: getTests(state),
+});
 
 const mapDispatchToProps = (dispatch) => ({
-    testing: () => dispatch(fetchTestService()),
-})
+  testing: () => dispatch(fetchTestService()),
+});
 
 class TestSection extends React.Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-        };
-    }
+  constructor(props) {
+    super(props);
+    this.state = {};
+  }
 
-    render () {
-        const { users } = this.props;
-        console.log('component accessible data ', users);
-        const test = users.map((user) => (
-            <div>
-                <div><b>Name:</b> {user.Name}</div>
-                <div><b>Email:</b> {user.Email__c}</div>
-            </div>
-        ))
-        return (
-            <div style={{ height: "100vh" }}>
-                <Grid container style={{ height:"100%" }}>
-                    <PageHeader header="Test Page Header"/>
-                    <PageBody>
-                        <ContainedButton onClick={()=>console.log(this.props.testing())}>FETCH DATA</ContainedButton>
-                        <div>
-                            {test}
-                        </div>
-                    </PageBody>
-                </Grid>
-            </div>
-        )
-    }
+  render() {
+    const { users } = this.props;
+    console.log("component accessible data ", users);
+    const test = users.map((user) => (
+      <div>
+        <div>
+          <b>Name:</b> {user.Name}
+        </div>
+        <div>
+          <b>Email:</b> {user.Email__c}
+        </div>
+      </div>
+    ));
+    return (
+      <div style={{ height: "100vh" }}>
+        <Grid container style={{ height: "100%" }}>
+          <PageHeader>
+            <Grid
+              item
+              container
+              direction="row"
+              justify="flex-start"
+              alignItems="flex-end"
+              style={{ height: "100%", width: "100%" }}
+            >
+              <Grid item>
+                <Typography variant="h1" style={{ marginBottom: "30%" }}>
+                  Test Page
+                </Typography>
+              </Grid>
+            </Grid>
+          </PageHeader>
+          <PageBody>
+            <ContainedButton onClick={() => console.log(this.props.testing())}>
+              FETCH DATA
+            </ContainedButton>
+            <div>{test}</div>
+          </PageBody>
+        </Grid>
+      </div>
+    );
+  }
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(TestSection);


### PR DESCRIPTION
Simplify page header styling so users can add child components. A quick demo of how the `PageHeader` and `PageBody` should be used is in `TestSection.tsx`.